### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > # This repo is deprecated. Use https://github.com/cortical-io/python-client-sdk
 
-# Pycept [![Build Status](https://travis-ci.org/numenta/pycept.svg?branch=master)](https://travis-ci.org/numenta/pycept) [![Coverage Status](https://coveralls.io/repos/numenta/pycept/badge.png?branch=master)](https://coveralls.io/r/numenta/pycept?branch=master) [![PyPi version](https://pypip.in/v/pycept/badge.png)](https://crate.io/packages/pycept/)
+# Pycept [![Build Status](https://travis-ci.org/numenta/pycept.svg?branch=master)](https://travis-ci.org/numenta/pycept) [![Coverage Status](https://coveralls.io/repos/numenta/pycept/badge.png?branch=master)](https://coveralls.io/r/numenta/pycept?branch=master) [![PyPi version](https://img.shields.io/pypi/v/pycept.svg)](https://crate.io/packages/pycept/)
 
 ## A python client for the CEPT API
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pycept))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pycept`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.